### PR TITLE
Add encoding='utf-8' to open()

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -215,7 +215,7 @@ def Generate(replacements):
 
     tmp_svg = os.path.join(globaldata.tempdir, 'temp.svg')
 
-    with open(tmp_svg, 'w') as f:
+    with open(tmp_svg, 'w', encoding='utf-8') as f:
         f.write(template)
 
     if globaldata.args.format == 'SVG':
@@ -378,10 +378,10 @@ try:
     if outdir != '' and not os.path.exists(outdir):
         os.makedirs(outdir)
 
-    with open(globaldata.args.infile, 'r') as f:
+    with open(globaldata.args.infile, 'r', encoding='utf-8') as f:
         globaldata.template = f.read()
 
-    with open(globaldata.args.datafile, 'r') as csvfile:
+    with open(globaldata.args.datafile, 'r', encoding='utf-8') as csvfile:
         Process_csv_file(csvfile)
 
 finally:


### PR DESCRIPTION
My environment:
Windows 10 (Japanese system locale), Inkscape 1.01

Problem:
When I run the extension in Inkscape, generator.py throws an error like this:
```
Traceback (most recent call last):
  File "generator.py", line 382, in <module>
    globaldata.template = f.read()
UnicodeDecodeError: 'cp932' codec can't decode byte 0x89 in position 616: illegal multibyte sequence
```

Solution:
Added encoding='utf-8' argument to open() and the extension worked fine for me.

FYI, this section of the doc has an example in regards to the system default encoding.
https://docs.python.org/3/library/csv.html#examples